### PR TITLE
Removing state pollution caused by uncleaned cache files

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 """Automated testing for Basic"""
 import os
+import shutil
 import string
 import random
 import pytest
@@ -55,6 +56,7 @@ def test_check_config_dir():
     # Test writing to read only
     assert Auth(
         config_dir="config/readonly/test").create_config_directory() is False
+    shutil.rmtree("config")
 
 
 def test_check_file_exists():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_check_config_dir` by removing state pollution caused by unclleaned cache files by calling method `shutil.rmtree`

The test can fail in this way if cache files are mot removed:
```
>       assert AUTH.check_config_dir() is False
E       assert True is False
E        +  where True = <bound method Auth.check_config_dir of <basic_auth.basic_auth.Auth object at 0x7f5cc027a700>>()
E        +    where <bound method Auth.check_config_dir of <basic_auth.basic_auth.Auth object at 0x7f5cc027a700>> = <basic_auth.basic_auth.Auth object at 0x7f5cc027a700>.check_config_dir
```